### PR TITLE
Using calc is not supported in media queries.

### DIFF
--- a/lib/components/_layout.scss
+++ b/lib/components/_layout.scss
@@ -45,7 +45,7 @@
 }
 
 // For small tablets and smartphones
-@media (max-width: calc($width-tablet - 1)) {
+@media (max-width: $width-tablet - 1) {
 
     #globalheader-container {
         position: static;

--- a/lib/components/entry/_header.scss
+++ b/lib/components/entry/_header.scss
@@ -45,7 +45,7 @@
 }
 
 // For small tablets
-@media (max-width: calc($width-tablet - 1)) {
+@media (max-width: $width-tablet - 1) {
     .entry-header-menu {
         top: -30px;
         left: 0px;

--- a/lib/components/sidebar/_box2-inner.scss
+++ b/lib/components/sidebar/_box2-inner.scss
@@ -6,7 +6,7 @@
 }
 
 // For small tablets
-@media (max-width: calc($width-tablet - 1)) {
+@media (max-width: $width-tablet - 1) {
     #box2-inner {
         width: 100%;
     }

--- a/lib/objects/sidebar/_hatena-module.scss
+++ b/lib/objects/sidebar/_hatena-module.scss
@@ -18,7 +18,7 @@
 }
 
 // For small tablets
-@media (max-width: calc($width-tablet - 1)) {
+@media (max-width: $width-tablet - 1) {
     .hatena-module {
         width: 100%;
         float: none;


### PR DESCRIPTION
Since using `calc` is not supported in media queries, layout is broken when window size is less than `$width-tablet`.

https://www.w3.org/TR/css3-mediaqueries/#media1

> Properties may accept more complex values, e.g., calculations that involve several other values. Media features only accept single values: one keyword, one number, or a number with a unit identifier. (The only exceptions are the ‘aspect-ratio’ and ‘device-aspect-ratio’ media features.)